### PR TITLE
focus_calc: NATS focus-calculation job service (boilerplate / API proposal)

### DIFF
--- a/config/focus_calc.sample.yaml
+++ b/config/focus_calc.sample.yaml
@@ -1,0 +1,32 @@
+# Sample configuration for the focus-calculation service.
+# Copy the service entry into your services.yaml (or run this file
+# directly: poetry run tcsd --config config/focus_calc.sample.yaml).
+#
+# Protocol and payloads: doc/focus-calc-service.md
+# Requires extras: pip install ocabox-tcs[focus]   (pyaraucaria)
+# JetStream: provision a stream covering `focus.calc.>` first
+# (oca_nats_config).
+
+nats:
+  host: localhost
+  port: 4222
+
+services:
+  - type: focus_calc_svc.focus_calc
+    instance_context: main
+    # All subjects live under this root:
+    #   IN   focus.calc.job.<job.id…>
+    #   OUT  focus.calc.result.<effective_id>
+    #   OUT  focus.calc.state.<effective_id>
+    subject_root: focus.calc
+    # Methods when an `open` message names none. Available:
+    # rms, rms_quad, fwhm, laplacian, lorentzian (pyaraucaria; the
+    # same algorithms TOI uses), dynamic_search (stub).
+    default_methods: [laplacian]
+    # Close a job after this much input silence (client can override
+    # per job in the `open` payload).
+    default_idle_timeout_s: 300
+    # Frame-directory polling cadence; explicit `file` messages work
+    # without waiting for the poll.
+    poll_interval_s: 2.0
+    max_jobs: 16

--- a/doc/focus-calc-service.md
+++ b/doc/focus-calc-service.md
@@ -1,0 +1,150 @@
+# focus_calc — NATS focus-calculation service
+
+Status: **boilerplate / API proposal** (PR for discussion). The wire
+protocol below is the contract we want to stabilise; the batch methods
+already work (via `pyaraucaria`), dynamic search is a stub.
+
+## What it is
+
+A permanent TCS service that computes best-focus from FITS frames, as
+**jobs** driven entirely over NATS sub/pub. The service never moves
+hardware — the client (TOI, plan-runner, a script) drives the focuser
+and tells the service where the frames land.
+
+Design points, in requirements order:
+
+- **N concurrent jobs**, each bound to a frame directory. Frames may
+  all exist up front, or trickle in during a scan — every new frame
+  triggers a re-evaluation and fresh results ("iterative improvement").
+- **M methods per job** on the same frames — one result message per
+  method per round. Methods are the existing TOI/pyaraucaria
+  algorithms (`rms`, `rms_quad`, `fwhm`, `laplacian`, `lorentzian`);
+  the plug-in protocol also anticipates **dynamic-search** methods
+  that suggest the next focuser position or convergence
+  (`suggestion.kind: next_position | stop | none`).
+- **Client-defined scans**: the `open` message may carry a `scan`
+  descriptor (informational for now) — the client executes it, we
+  refine after each frame.
+- **Job closure**: explicit `stop` message, or idle timeout (no new
+  input for `idle_timeout_s`).
+- **Sub/pub, not RPC** — a job is a long-lived conversation with many
+  messages in both directions. (RPC for a fixed, complete image set is
+  a possible later convenience wrapper.)
+
+## Subjects
+
+All under a configurable root (default `focus.calc`):
+
+```
+IN   focus.calc.job.<id.part1[.part2…]>     commands (open / file / stop)
+OUT  focus.calc.result.<effective_id>       one message per method per round
+OUT  focus.calc.state.<effective_id>        lifecycle (opened / rejected / closed)
+```
+
+**The subject suffix is the job id.** The client picks it (dots
+allowed, e.g. `zb08.20260804.autofocus`); all responses use the same
+suffix. If the id was already used by a *finished* job, the service
+appends `.h<8-hex>` and announces the **effective id** in the
+`opened` state message — clients must subscribe to
+`focus.calc.result.<effective_id>` (or just `focus.calc.result.<their.id>.>`
+plus the exact id, to cover both cases).
+
+Messages to an *active* id join the running job — that is how `file`
+and `stop` reach it.
+
+### JetStream
+
+A stream must cover `focus.calc.>` — provision via
+[oca_nats_config](https://github.com/araucaria-project/oca_nats_config)
+before deploying (same lesson as `tic.command.>`; the guider fails
+fast on uncovered publish subjects and this service should follow once
+it grows past boilerplate).
+
+## Payloads
+
+`open` (implicit when the first message for a new id carries `path`):
+
+```json
+{
+  "action": "open",
+  "path": "/data/zb08/focus/actual",
+  "methods": ["laplacian", "rms_quad"],
+  "params": {"focus_keyword": "FOCUS", "crop": 10},
+  "idle_timeout_s": 300,
+  "scan": {"start": 14000, "stop": 16000, "step": 100}
+}
+```
+
+`file` — optional explicit notification (folder is also polled every
+`poll_interval_s`, so pure file-drop clients work too):
+
+```json
+{"action": "file", "filename": "zb08c_0042.fits"}
+```
+
+`stop`:
+
+```json
+{"action": "stop"}
+```
+
+`result` (per method, per round; `fit` mirrors what TOI's focus window
+plots today):
+
+```json
+{
+  "seq": 7,
+  "job_id": "zb08.20260804",
+  "effective_id": "zb08.20260804",
+  "method": "laplacian",
+  "status": "ok",                    // partial | ok | failed
+  "best_focus": 15230.0,
+  "files_used": 9,
+  "suggestion": {"kind": "none", "position": null},
+  "fit": {"coef": [...], "focus_values": [...], "sharpness_values": [...],
+          "fit_x": [...], "fit_y": [...]},
+  "message": ""
+}
+```
+
+`state` events: `opened` (carries `effective_id`, echo of parameters),
+`rejected` (reason: job limit, missing path), `closed` (reason: stop /
+idle / service stopping, plus `final` — last result of every method).
+
+## Service configuration
+
+```yaml
+services:
+  - type: focus_calc_svc.focus_calc
+    instance_context: main
+    subject_root: focus.calc
+    default_methods: [laplacian]
+    default_idle_timeout_s: 300
+    poll_interval_s: 2.0
+    max_jobs: 16
+```
+
+Dependencies: `pip install ocabox-tcs[focus]` (pulls `pyaraucaria`).
+Without the extra the service boots and honestly reports batch methods
+as unavailable (per-method `failed` results + discovery metrics).
+
+## Observability
+
+Standard TCS monitoring (status, heartbeat, `tcsctl`). Metrics
+(`tcsctl --detailed`): method availability map, active job table
+(path, files, rounds, methods), message/result counters, last error.
+Modelling jobs as TCS child components (hierarchical monitoring) is a
+noted option once multi-component services land (roadmap Feature 3).
+
+## Open questions for review
+
+1. Subject root — `focus.calc` vs something under an existing family
+   (`svc.focus.…`? telescope-scoped roots?).
+2. Should `scan` be enforced (service checks incoming frames against
+   the declared plan) or stay informational?
+3. RPC wrapper for the complete-set case — worth it, or does a
+   one-shot job (open + immediate stop after last file) suffice?
+4. Result retention: JetStream limits for `focus.calc.result.>`
+   (suggested: days, like `svc_status`).
+5. Per-file sharpness caching in `VCurveMethod` (currently re-measures
+   all frames each round — fine for ≤20-frame scans, wasteful beyond).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ aiohttp = {version = "^3.9", optional = true}  # direct Alpaca imagebytes fetch 
 pillow = {version = "^10.0", optional = true}  # JPEG encoding for thumbnail_emitter; star-cutout previews in solver methods
 padasip = {version = "^1.2", optional = true}  # auto_adjust RLSAdapter
 scikit-learn = {version = "^1.4", optional = true}  # auto_adjust GPAdapter
+pyaraucaria = {git = "https://github.com/araucaria-project/pyaraucaria.git", optional = true}  # focus_calc_svc batch methods (Focus.calculate — same algorithms TOI uses)
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"
@@ -55,6 +56,7 @@ oca = ["ocabox"]  # OCABOX integration, running ocabox dependent services
 guider = ["astropy", "aiohttp", "pillow"]  # full guiding_svc dependencies (FITS reading, stacking math, direct Alpaca fetch, JPEG thumbnail encoding)
 adjust-rls = ["padasip"]  # auto_adjust RLSAdapter
 adjust-gp = ["scikit-learn"]  # auto_adjust GPAdapter
+focus = ["pyaraucaria", "astropy"]  # focus_calc_svc (FITS + TOI focus algorithms)
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/ocabox_tcs/services/focus_calc_svc/__init__.py
+++ b/src/ocabox_tcs/services/focus_calc_svc/__init__.py
@@ -1,0 +1,6 @@
+"""focus_calc_svc — NATS-driven focus-calculation job service.
+
+See ``focus_calc.py`` for the service, ``jobs.py`` for job lifecycle,
+``methods.py`` for the pluggable algorithm layer, and
+``doc/focus-calc-service.md`` for the message protocol.
+"""

--- a/src/ocabox_tcs/services/focus_calc_svc/focus_calc.py
+++ b/src/ocabox_tcs/services/focus_calc_svc/focus_calc.py
@@ -1,0 +1,246 @@
+"""Focus-calculation service — NATS-driven, multi-job, multi-method.
+
+Service type: ``focus_calc_svc.focus_calc`` (filename-derived).
+
+A permanent TCS service that runs focus calculations as *jobs*. A job
+is opened by a message pointing at a directory of FITS frames (which
+may still be empty — frames can trickle in during a focuser scan); the
+service re-evaluates the requested methods after every new frame and
+publishes one result message per method per round, including partial
+results and — for dynamic-search methods — a suggested next focuser
+position or a convergence signal. The service never touches hardware;
+the client (TOI, plan runner, a script) drives the focuser.
+
+Message protocol (full spec: ``doc/focus-calc-service.md``)::
+
+    IN   <root>.job.<job.id.parts...>      command channel (sub/pub, JetStream)
+    OUT  <root>.result.<effective.id>      one message per method per round
+    OUT  <root>.state.<effective.id>       job lifecycle: opened/rejected/closed
+
+The subject suffix after ``<root>.job.`` is the client-chosen job id;
+responses reuse it. If the id was already used by a finished job, the
+service appends ``.h<hash>`` and announces the *effective id* in the
+``opened`` message. Sub/pub (not RPC) because a job is a long-lived
+conversation with many messages both ways; a fixed-image-set RPC
+variant is a possible later addition.
+
+Configuration (YAML)::
+
+    services:
+      - type: focus_calc_svc.focus_calc
+        instance_context: main
+        subject_root: focus.calc          # subjects live under this root
+        default_methods: [laplacian]      # when 'open' names none
+        default_idle_timeout_s: 300       # close job after silence
+        poll_interval_s: 2.0              # folder polling cadence
+        max_jobs: 16
+
+JetStream: a stream must cover ``<root>.>`` (provision via
+oca_nats_config, same as ``tic.command.>`` — see project follow-ups).
+
+Observability: standard TCS status/heartbeat; metrics expose active
+job count, per-job round counters and the method-availability map, so
+``tcsctl --detailed`` shows at a glance what this instance can do.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from serverish.messenger import get_callbacksubscriber, get_publisher
+
+from ocabox_tcs.base_service import (
+    BaseBlockingPermanentService,
+    BaseServiceConfig,
+    config,
+    service,
+)
+from ocabox_tcs.monitoring import Status
+from ocabox_tcs.services.focus_calc_svc.jobs import JobManager
+from ocabox_tcs.services.focus_calc_svc.methods import available_methods
+
+
+logger = logging.getLogger(__name__.rsplit(".", maxsplit=1)[-1])
+
+
+@config("focus_calc_svc.focus_calc")
+@dataclass
+class FocusCalcConfig(BaseServiceConfig):
+    """Configurable surface of the focus-calculation service."""
+
+    #: All subjects (job/result/state) hang under this root.
+    subject_root: str = "focus.calc"
+    #: Methods used when an ``open`` message names none.
+    default_methods: list[str] = field(default_factory=lambda: ["laplacian"])
+    #: Job auto-close after this much input silence (no new frames,
+    #: no messages). Client can override per job.
+    default_idle_timeout_s: float = 300.0
+    #: Folder-poll cadence. Explicit ``file`` messages work without
+    #: polling; the poll catches clients that only drop files.
+    poll_interval_s: float = 2.0
+    #: Ceiling on concurrently open jobs; further opens are rejected.
+    max_jobs: int = 16
+
+
+@service("focus_calc_svc.focus_calc")
+class FocusCalcService(BaseBlockingPermanentService):
+    """Run N concurrent focus-calculation jobs over NATS.
+
+    Lifecycle:
+        - ``on_start`` → build the :class:`JobManager`, open the
+          command subscriber on ``<root>.job.>``, register metrics
+          and healthcheck callbacks.
+        - ``run_service`` → periodic tick: folder polling and idle
+          expiry, until the framework cancels us.
+        - ``on_stop`` → close the subscriber, close remaining jobs
+          (clients get a ``closed`` state message with the final
+          results and reason ``service stopping``).
+
+    Job children as separate TCS-monitored objects: deliberate later
+    option (multi-component services, roadmap Feature 3) — for now
+    jobs surface through this service's metrics.
+    """
+
+    svc_config: FocusCalcConfig
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._manager: JobManager | None = None
+        self._command_sub: Any | None = None
+        self._publishers: dict[str, Any] = {}   # subject → MsgPublisher
+        self._messages_in = 0
+        self._last_error: str | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def on_start(self) -> None:
+        cfg = self.svc_config
+        self._manager = JobManager(
+            publish_result=self._make_publish("result"),
+            publish_status=self._make_publish("state"),
+            default_methods=list(cfg.default_methods),
+            default_idle_timeout_s=cfg.default_idle_timeout_s,
+            max_jobs=cfg.max_jobs,
+        )
+        # ``deliver_policy='new'``: commands from before a restart must
+        # not replay — a stale ``open`` would resurrect a dead job and
+        # start publishing into a conversation nobody listens to.
+        self._command_sub = get_callbacksubscriber(
+            f"{cfg.subject_root}.job.>",
+            deliver_policy="new",
+        )
+        await self._command_sub.open()
+        await self._command_sub.subscribe(self._on_command)
+        self.monitor.add_metric_cb(self._metrics)
+        self.monitor.add_healthcheck_cb(self._healthcheck)
+        self.svc_logger.info(
+            "FocusCalc ready: subscribed %s.job.> (methods: %s)",
+            cfg.subject_root,
+            ", ".join(f"{k}={v}" for k, v in available_methods().items()),
+        )
+
+    async def run_service(self) -> None:
+        assert self._manager is not None
+        while self.is_running:
+            try:
+                await self._manager.tick()
+            except Exception as exc:  # noqa: BLE001 — tick must survive anything
+                self._last_error = str(exc)
+                self.svc_logger.exception("job tick failed: %s", exc)
+            await asyncio.sleep(self.svc_config.poll_interval_s)
+
+    async def on_stop(self) -> None:
+        if self._command_sub is not None:
+            try:
+                await self._command_sub.close()
+            except Exception as exc:  # noqa: BLE001 — defensive teardown
+                self.svc_logger.warning("error closing command subscriber: %s", exc)
+            self._command_sub = None
+        if self._manager is not None:
+            await self._manager.close_all(reason="service stopping")
+        for pub in self._publishers.values():
+            try:
+                await pub.close()
+            except Exception:  # noqa: BLE001 — defensive teardown
+                pass
+        self._publishers.clear()
+
+    # ------------------------------------------------------------------
+    # NATS plumbing
+    # ------------------------------------------------------------------
+
+    async def _on_command(self, data: dict, meta: dict) -> bool:
+        """``MsgCallbackSubscriber`` callback on ``<root>.job.>``.
+        Always returns True — a bad message must not stop the stream."""
+        self._messages_in += 1
+        subject = (meta or {}).get("nats", {}).get("subject")
+        prefix = f"{self.svc_config.subject_root}.job."
+        if not subject or not subject.startswith(prefix):
+            self.svc_logger.error("command without usable subject (%r) — dropped", subject)
+            return True
+        job_id = subject[len(prefix):]
+        if not job_id:
+            self.svc_logger.error("command with empty job suffix — dropped")
+            return True
+        try:
+            assert self._manager is not None
+            await self._manager.handle_message(job_id, data or {})
+        except Exception as exc:  # noqa: BLE001 — channel must survive
+            self._last_error = str(exc)
+            self.svc_logger.exception("handling command for job %s failed: %s", job_id, exc)
+        return True
+
+    def _make_publish(self, leaf: str):
+        """Publisher callable bound to ``<root>.<leaf>.<effective_id>``,
+        with per-subject publisher caching."""
+        root = self.svc_config.subject_root
+
+        async def _publish(effective_id: str, payload: dict[str, Any]) -> None:
+            subject = f"{root}.{leaf}.{effective_id}"
+            pub = self._publishers.get(subject)
+            if pub is None:
+                pub = get_publisher(subject)
+                self._publishers[subject] = pub
+            await pub.publish(data=payload)
+
+        return _publish
+
+    # ------------------------------------------------------------------
+    # Observability
+    # ------------------------------------------------------------------
+
+    def _metrics(self) -> dict[str, Any]:
+        mgr = self._manager
+        return {
+            "focus_calc": {
+                "subject_root": self.svc_config.subject_root,
+                "methods": available_methods(),
+                "jobs_active": len(mgr.jobs) if mgr else 0,
+                "jobs": {
+                    eid: {
+                        "path": str(j.path),
+                        "files": len(j.files),
+                        "rounds": j.seq,
+                        "methods": j.method_names,
+                    }
+                    for eid, j in (mgr.jobs.items() if mgr else ())
+                },
+                "messages_in": self._messages_in,
+                "results_published": mgr.results_published if mgr else 0,
+                "last_error": self._last_error,
+            }
+        }
+
+    def _healthcheck(self) -> Status:
+        if self._command_sub is None:
+            return Status.ERROR
+        return Status.OK
+
+
+if __name__ == "__main__":
+    FocusCalcService.main()

--- a/src/ocabox_tcs/services/focus_calc_svc/jobs.py
+++ b/src/ocabox_tcs/services/focus_calc_svc/jobs.py
@@ -1,0 +1,263 @@
+"""Job model and manager for the focus-calculation service.
+
+A *job* is one focusing session: a directory of FITS frames (possibly
+still being written), a set of methods to run, and a NATS suffix under
+which all of its traffic flows.
+
+Job identity
+------------
+The inbound subject's suffix (everything after the configured command
+root, dots preserved) IS the client-chosen job id, e.g. a message on
+``focus.calc.job.zb08.20260804`` addresses job ``zb08.20260804``.
+Responses are published with the same suffix. If a client reuses the
+id of a *finished* job, the manager mints an *effective id* by
+appending ``.h<8-hex>`` — the ``opened`` status message tells the
+client which id to listen on. Messages for an *active* id always join
+the running job (that is how files/stop reach it).
+
+Lifecycle
+---------
+``open`` (explicit, or implicit with the first message carrying a
+``path``) → any number of ``file`` notifications and/or folder-poll
+discoveries, each triggering an update round (all methods re-evaluated,
+one result message per method) → ``stop`` message, or idle timeout
+(no new input for ``idle_timeout_s``) → ``closed`` status with final
+results.
+
+The manager is transport-agnostic: the service wires ``publish_result``
+/ ``publish_status`` callables; tests inject fakes and a fake clock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from ocabox_tcs.services.focus_calc_svc.methods import (
+    FocusMethod,
+    MethodResult,
+    create_method,
+)
+
+
+logger = logging.getLogger(__name__.rsplit(".", maxsplit=1)[-1])
+
+#: Frame extensions picked up by the folder poll.
+_FITS_SUFFIXES = {".fits", ".fit", ".fts"}
+
+PublishCb = Callable[[str, dict[str, Any]], Awaitable[None]]
+"""(effective_job_id, payload) → publish coroutine."""
+
+
+@dataclass
+class FocusJob:
+    """State of one focusing session."""
+
+    job_id: str                     # client-chosen suffix
+    effective_id: str               # job_id, possibly + ".h<hash>"
+    path: Path                      # frame directory (may not exist yet)
+    method_names: list[str]
+    params: dict[str, Any] = field(default_factory=dict)
+    idle_timeout_s: float = 300.0
+    scan: dict[str, Any] | None = None   # client-declared focuser scan plan (informational)
+
+    files: list[str] = field(default_factory=list)
+    methods: dict[str, FocusMethod] = field(default_factory=dict)
+    last_results: dict[str, MethodResult] = field(default_factory=dict)
+    seq: int = 0                    # update round counter
+    last_input_mono: float = 0.0    # monotonic time of last new input
+    closed: bool = False
+
+    def discover_new_files(self) -> list[str]:
+        """Poll the job directory for frames not seen yet (sorted by
+        mtime so arrival order survives batch drops). Missing directory
+        is fine — frames may not exist yet."""
+        if not self.path.is_dir():
+            return []
+        known = set(self.files)
+        found = [
+            p for p in self.path.iterdir()
+            if p.suffix.lower() in _FITS_SUFFIXES and str(p) not in known
+        ]
+        found.sort(key=lambda p: p.stat().st_mtime)
+        return [str(p) for p in found]
+
+
+class JobManager:
+    """Owns all live jobs; the service delegates message handling and
+    periodic ticking here."""
+
+    def __init__(
+        self,
+        publish_result: PublishCb,
+        publish_status: PublishCb,
+        *,
+        default_methods: list[str] | None = None,
+        default_idle_timeout_s: float = 300.0,
+        max_jobs: int = 16,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._publish_result = publish_result
+        self._publish_status = publish_status
+        self._default_methods = default_methods or ["laplacian"]
+        self._default_idle_timeout_s = default_idle_timeout_s
+        self._max_jobs = max_jobs
+        self._clock = clock
+        self.jobs: dict[str, FocusJob] = {}       # keyed by effective_id
+        self._finished_ids: set[str] = set()       # client ids ever used & closed
+        self.results_published = 0
+
+    # ------------------------------------------------------------------
+    # Message entry point
+    # ------------------------------------------------------------------
+
+    async def handle_message(self, job_id: str, data: dict[str, Any]) -> None:
+        """Dispatch one inbound message addressed to ``job_id`` (the
+        raw subject suffix)."""
+        action = data.get("action") or ("open" if "path" in data else None)
+        job = self._find_active(job_id)
+
+        if action == "open" and job is None:
+            await self._open(job_id, data)
+        elif action == "open":
+            # Re-open of a live id: treat as a parameter nudge, not an
+            # error — but a changed path means the client really wants
+            # a fresh job under a fresh id.
+            logger.warning("job %s: 'open' while active — ignored", job.effective_id)
+        elif job is None:
+            logger.warning("message for unknown/closed job %s (action=%s) — dropped",
+                           job_id, action)
+        elif action == "file":
+            fname = data.get("filename")
+            if fname:
+                await self._ingest(job, [str(Path(job.path) / fname)
+                                         if not Path(fname).is_absolute() else fname])
+        elif action == "stop":
+            await self.close_job(job, reason="stop requested")
+        else:
+            logger.warning("job %s: unknown action %r — dropped", job.effective_id, action)
+
+    # ------------------------------------------------------------------
+    # Periodic tick (folder polling + idle expiry)
+    # ------------------------------------------------------------------
+
+    async def tick(self) -> None:
+        for job in list(self.jobs.values()):
+            new = job.discover_new_files()
+            if new:
+                await self._ingest(job, new)
+            elif (self._clock() - job.last_input_mono) > job.idle_timeout_s:
+                await self.close_job(job, reason=f"idle > {job.idle_timeout_s:.0f}s")
+
+    async def close_all(self, reason: str) -> None:
+        for job in list(self.jobs.values()):
+            await self.close_job(job, reason=reason)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _find_active(self, job_id: str) -> FocusJob | None:
+        for job in self.jobs.values():
+            if job.job_id == job_id and not job.closed:
+                return job
+        return None
+
+    def _effective_id(self, job_id: str) -> str:
+        """Client id verbatim while unique; append a short stable-ish
+        hash once the id has already lived and died."""
+        if job_id not in self._finished_ids and job_id not in {
+            j.job_id for j in self.jobs.values()
+        }:
+            return job_id
+        salt = f"{job_id}:{self._clock():.6f}".encode()
+        return f"{job_id}.h{hashlib.blake2b(salt, digest_size=4).hexdigest()}"
+
+    async def _open(self, job_id: str, data: dict[str, Any]) -> None:
+        if len(self.jobs) >= self._max_jobs:
+            await self._publish_status(job_id, {
+                "event": "rejected", "job_id": job_id,
+                "reason": f"job limit reached ({self._max_jobs})",
+            })
+            return
+        path = data.get("path")
+        if not path:
+            await self._publish_status(job_id, {
+                "event": "rejected", "job_id": job_id,
+                "reason": "open requires 'path'",
+            })
+            return
+        effective = self._effective_id(job_id)
+        job = FocusJob(
+            job_id=job_id,
+            effective_id=effective,
+            path=Path(path),
+            method_names=list(data.get("methods") or self._default_methods),
+            params=dict(data.get("params") or {}),
+            idle_timeout_s=float(data.get("idle_timeout_s")
+                                 or self._default_idle_timeout_s),
+            scan=data.get("scan"),
+            last_input_mono=self._clock(),
+        )
+        for name in job.method_names:
+            try:
+                job.methods[name] = create_method(name)
+            except (ValueError, RuntimeError) as exc:
+                # Unknown/unavailable method → permanent failed result,
+                # the job still runs the others.
+                job.last_results[name] = MethodResult(
+                    method=name, status="failed", message=str(exc))
+                logger.warning("job %s: method %s unavailable: %s",
+                               effective, name, exc)
+        self.jobs[effective] = job
+        logger.info("job %s opened: path=%s methods=%s idle_timeout=%.0fs",
+                    effective, job.path, job.method_names, job.idle_timeout_s)
+        await self._publish_status(effective, {
+            "event": "opened",
+            "job_id": job_id,
+            "effective_id": effective,
+            "path": str(job.path),
+            "methods": job.method_names,
+            "idle_timeout_s": job.idle_timeout_s,
+        })
+        # Frames may already be waiting in the folder.
+        pre = job.discover_new_files()
+        if pre:
+            await self._ingest(job, pre)
+
+    async def _ingest(self, job: FocusJob, new_files: list[str]) -> None:
+        job.files.extend(new_files)
+        job.last_input_mono = self._clock()
+        job.seq += 1
+        for name, method in job.methods.items():
+            result = await method.update(job.files, job.params)
+            job.last_results[name] = result
+            self.results_published += 1
+            await self._publish_result(job.effective_id, {
+                "seq": job.seq,
+                "job_id": job.job_id,
+                "effective_id": job.effective_id,
+                **result.to_payload(),
+            })
+
+    async def close_job(self, job: FocusJob, *, reason: str) -> None:
+        if job.closed:
+            return
+        job.closed = True
+        self.jobs.pop(job.effective_id, None)
+        self._finished_ids.add(job.job_id)
+        logger.info("job %s closed (%s): %d files, %d rounds",
+                    job.effective_id, reason, len(job.files), job.seq)
+        await self._publish_status(job.effective_id, {
+            "event": "closed",
+            "job_id": job.job_id,
+            "effective_id": job.effective_id,
+            "reason": reason,
+            "files_total": len(job.files),
+            "final": {n: r.to_payload() for n, r in job.last_results.items()},
+        })

--- a/src/ocabox_tcs/services/focus_calc_svc/methods.py
+++ b/src/ocabox_tcs/services/focus_calc_svc/methods.py
@@ -1,0 +1,251 @@
+"""Pluggable focus-calculation methods.
+
+A *method* consumes the set of FITS files accumulated so far by a job
+and produces a (possibly partial) :class:`MethodResult`. Several
+methods may run within one job on the same files — the job publishes
+one result message per method per update.
+
+Two families are anticipated:
+
+- **Batch / V-curve methods** (available now): sharpness is measured
+  per frame, a curve is fitted over (focus, sharpness) pairs, the
+  extremum is the answer. Every new file simply re-fits over the
+  fuller dataset — "iterative improvement" falls out for free. These
+  wrap :class:`pyaraucaria.focus.Focus` (the algorithms TOI uses
+  today: ``rms``, ``rms_quad``, ``fwhm``, ``laplacian``,
+  ``lorentzian``).
+- **Dynamic-search methods** (stub): minimisation-style algorithms
+  that after each frame *suggest* the next focuser position (or
+  declare convergence) instead of requiring a pre-planned scan. The
+  protocol carries the suggestion; the algorithm is future work.
+
+``pyaraucaria`` is an optional dependency (extra ``focus``); the
+module imports without it, and the registry simply reports the batch
+methods as unavailable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+
+logger = logging.getLogger(__name__.rsplit(".", maxsplit=1)[-1])
+
+try:  # optional dependency (extra: focus)
+    from pyaraucaria.focus import Focus as _PyaFocus
+except ImportError:  # pragma: no cover - exercised only without extras
+    _PyaFocus = None
+
+
+@dataclass
+class Suggestion:
+    """Advice for the client driving the focuser.
+
+    ``kind``:
+        - ``"next_position"`` — try this focuser position next
+          (dynamic-search methods; ``position`` is set),
+        - ``"stop"`` — the method believes it has converged; further
+          frames won't improve the result,
+        - ``"none"`` — no advice (typical for batch methods mid-scan).
+    """
+
+    kind: str = "none"
+    position: float | None = None
+
+
+@dataclass
+class MethodResult:
+    """One method's answer after ingesting the files seen so far.
+
+    ``status``:
+        - ``"partial"`` — not enough data for a trustworthy fit yet
+          (or fit quality below par); ``best_focus`` may still carry
+          a provisional value,
+        - ``"ok"`` — converged / fit healthy,
+        - ``"failed"`` — method cannot produce a result from this
+          dataset (and says why in ``message``).
+
+    ``fit`` carries method-specific curve data for plotting (TOI's
+    focus window reads the same shape: ``focus_values``,
+    ``sharpness_values``, ``fit_x``, ``fit_y``, ``coef``).
+    """
+
+    method: str
+    status: str
+    best_focus: float | None = None
+    files_used: int = 0
+    suggestion: Suggestion = field(default_factory=Suggestion)
+    fit: dict[str, Any] = field(default_factory=dict)
+    message: str = ""
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "method": self.method,
+            "status": self.status,
+            "best_focus": self.best_focus,
+            "files_used": self.files_used,
+            "suggestion": {
+                "kind": self.suggestion.kind,
+                "position": self.suggestion.position,
+            },
+            "fit": self.fit,
+            "message": self.message,
+        }
+
+
+@runtime_checkable
+class FocusMethod(Protocol):
+    """The contract every focus algorithm implements.
+
+    ``update`` is called with the *complete* list of files available
+    to the job so far (paths, ordered by arrival). Methods are free to
+    cache per-file measurements internally — the job guarantees a
+    method instance lives for the whole job and sees a monotonically
+    growing list.
+    """
+
+    name: str
+    #: Method can improve its answer as files trickle in.
+    iterative: bool
+    #: Method emits ``next_position`` suggestions (dynamic search).
+    suggests_next: bool
+
+    async def update(self, files: list[str], params: dict[str, Any]) -> MethodResult:
+        ...
+
+
+class VCurveMethod:
+    """Batch V-curve fit over all files seen so far — adapter around
+    :meth:`pyaraucaria.focus.Focus.calculate` (the exact code TOI runs
+    today, list-of-files form).
+
+    Focus positions come from the FITS header (``focus_keyword``,
+    default ``FOCUS``). Re-fits from scratch on every update; per-file
+    sharpness caching is a later optimisation (pyaraucaria recomputes
+    internally).
+    """
+
+    iterative = True
+    suggests_next = False
+
+    def __init__(self, name: str) -> None:
+        if _PyaFocus is None:
+            raise RuntimeError(
+                "pyaraucaria not installed — install extras: "
+                "pip install ocabox-tcs[focus]"
+            )
+        if name not in _PyaFocus.METHODS:
+            raise ValueError(f"unknown pyaraucaria focus method: {name!r}")
+        self.name = name
+        #: Minimum frames before a fit is attempted (polynomial degree
+        #: requirement lives in pyaraucaria; this is the cheap
+        #: pre-check so partials don't spam warnings).
+        self._min_files = int(_PyaFocus.METHODS[name].get("deg", 2)) + 1
+
+    async def update(self, files: list[str], params: dict[str, Any]) -> MethodResult:
+        if len(files) < self._min_files:
+            return MethodResult(
+                method=self.name, status="partial", files_used=len(files),
+                message=f"waiting for data: {len(files)}/{self._min_files} frames",
+            )
+        loop = asyncio.get_running_loop()
+        try:
+            # Focus.calculate is CPU/IO-bound synchronous code —
+            # keep the service loop responsive.
+            result = await loop.run_in_executor(
+                None,
+                lambda: _PyaFocus.calculate(
+                    fits_path=list(files),
+                    method=self.name,
+                    focus_keyword=params.get("focus_keyword", "FOCUS"),
+                    crop=int(params.get("crop", 10)),
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 — method failure is a result, not a crash
+            return MethodResult(
+                method=self.name, status="failed", files_used=len(files),
+                message=str(exc),
+            )
+        if result is None:
+            return MethodResult(
+                method=self.name, status="failed", files_used=len(files),
+                message="pyaraucaria returned no result",
+            )
+        best, meta = result
+        status = "ok" if meta.get("status") == "ok" else "partial"
+        return MethodResult(
+            method=self.name,
+            status=status,
+            best_focus=float(best),
+            files_used=len(files),
+            fit={
+                "coef": _aslist(meta.get("coef")),
+                "focus_values": _aslist(meta.get("focus_values")),
+                "sharpness_values": _aslist(meta.get("sharpness_values")),
+                "fit_x": _aslist(meta.get("fit_x")),
+                "fit_y": _aslist(meta.get("fit_y")),
+            },
+        )
+
+
+class DynamicSearchStub:
+    """Placeholder for minimisation-style dynamic focus search.
+
+    Target behaviour: after each frame propose the next focuser
+    position (``Suggestion(kind="next_position")``), converging like a
+    golden-section / parabolic line search, and emit
+    ``Suggestion(kind="stop")`` once the bracket is tight. The client
+    executes the suggestions — the service never moves hardware.
+
+    Not implemented — registered so the name and the wire contract are
+    stable from day one; selecting it yields honest ``failed`` results.
+    """
+
+    name = "dynamic_search"
+    iterative = True
+    suggests_next = True
+
+    async def update(self, files: list[str], params: dict[str, Any]) -> MethodResult:
+        return MethodResult(
+            method=self.name, status="failed", files_used=len(files),
+            message="dynamic_search is not implemented yet",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+_PYA_METHOD_NAMES = ("rms", "rms_quad", "fwhm", "laplacian", "lorentzian")
+
+
+def available_methods() -> dict[str, str]:
+    """Name → short availability note, for discovery metrics."""
+    out: dict[str, str] = {}
+    for name in _PYA_METHOD_NAMES:
+        out[name] = "ok" if _PyaFocus is not None else "unavailable (install ocabox-tcs[focus])"
+    out[DynamicSearchStub.name] = "stub (not implemented)"
+    return out
+
+
+def create_method(name: str) -> FocusMethod:
+    """Instantiate a method by name. Raises ``ValueError`` for unknown
+    names and ``RuntimeError`` when the backing library is missing —
+    the job turns either into a per-method ``failed`` result."""
+    if name == DynamicSearchStub.name:
+        return DynamicSearchStub()
+    if name in _PYA_METHOD_NAMES:
+        return VCurveMethod(name)
+    raise ValueError(f"unknown focus method: {name!r}")
+
+
+def _aslist(value: Any) -> list[Any] | None:
+    if value is None:
+        return None
+    try:
+        return [float(v) for v in value]
+    except TypeError:
+        return None

--- a/tests/unit/test_focus_calc_jobs.py
+++ b/tests/unit/test_focus_calc_jobs.py
@@ -1,0 +1,153 @@
+"""Unit tests for the focus_calc job layer (no NATS, no pyaraucaria).
+
+The JobManager is transport-agnostic: we inject recording publishers
+and a fake clock, and register a fake in-memory method via
+monkeypatching ``create_method``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ocabox_tcs.services.focus_calc_svc import jobs as jobs_mod
+from ocabox_tcs.services.focus_calc_svc.jobs import JobManager
+from ocabox_tcs.services.focus_calc_svc.methods import MethodResult, Suggestion
+
+
+class FakeMethod:
+    name = "fake"
+    iterative = True
+    suggests_next = True
+
+    async def update(self, files: list[str], params: dict[str, Any]) -> MethodResult:
+        return MethodResult(
+            method=self.name,
+            status="ok" if len(files) >= 3 else "partial",
+            best_focus=15000.0 + len(files),
+            files_used=len(files),
+            suggestion=Suggestion(kind="next_position", position=100.0 * len(files)),
+        )
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+@pytest.fixture
+def harness(monkeypatch, tmp_path):
+    results: list[tuple[str, dict]] = []
+    states: list[tuple[str, dict]] = []
+
+    async def pub_result(eid: str, payload: dict) -> None:
+        results.append((eid, payload))
+
+    async def pub_state(eid: str, payload: dict) -> None:
+        states.append((eid, payload))
+
+    monkeypatch.setattr(jobs_mod, "create_method", lambda name: FakeMethod())
+    clock = FakeClock()
+    mgr = JobManager(
+        pub_result, pub_state,
+        default_methods=["fake"],
+        default_idle_timeout_s=60.0,
+        max_jobs=2,
+        clock=clock,
+    )
+    return mgr, results, states, clock, tmp_path
+
+
+def _touch_fits(directory: Path, name: str) -> None:
+    (directory / name).write_bytes(b"SIMPLE  =                    T")
+
+
+async def test_open_publishes_opened_state(harness):
+    mgr, _results, states, _clock, tmp = harness
+    await mgr.handle_message("zb08.test", {"action": "open", "path": str(tmp)})
+    assert states[0][1]["event"] == "opened"
+    assert states[0][1]["effective_id"] == "zb08.test"
+    assert "zb08.test" in mgr.jobs
+
+
+async def test_implicit_open_via_path(harness):
+    mgr, _results, states, _clock, tmp = harness
+    await mgr.handle_message("j1", {"path": str(tmp)})
+    assert states[0][1]["event"] == "opened"
+
+
+async def test_open_without_path_rejected(harness):
+    mgr, _results, states, _clock, _tmp = harness
+    await mgr.handle_message("j1", {"action": "open"})
+    assert states[0][1]["event"] == "rejected"
+    assert not mgr.jobs
+
+
+async def test_files_trigger_results_per_round(harness):
+    mgr, results, _states, _clock, tmp = harness
+    _touch_fits(tmp, "a.fits")   # present before open → ingested at open
+    await mgr.handle_message("j1", {"action": "open", "path": str(tmp)})
+    assert len(results) == 1
+    assert results[0][1]["status"] == "partial"
+    assert results[0][1]["suggestion"]["kind"] == "next_position"
+
+    _touch_fits(tmp, "b.fits")
+    _touch_fits(tmp, "c.fits")
+    await mgr.tick()             # poll discovers 2 new frames → round 2
+    assert len(results) == 2
+    assert results[1][1]["files_used"] == 3
+    assert results[1][1]["status"] == "ok"
+    assert results[1][1]["seq"] == 2
+
+
+async def test_stop_closes_with_final_results(harness):
+    mgr, _results, states, _clock, tmp = harness
+    _touch_fits(tmp, "a.fits")
+    await mgr.handle_message("j1", {"action": "open", "path": str(tmp)})
+    await mgr.handle_message("j1", {"action": "stop"})
+    closed = states[-1][1]
+    assert closed["event"] == "closed"
+    assert closed["reason"] == "stop requested"
+    assert "fake" in closed["final"]
+    assert not mgr.jobs
+
+
+async def test_idle_timeout_closes_job(harness):
+    mgr, _results, states, clock, tmp = harness
+    await mgr.handle_message("j1", {"action": "open", "path": str(tmp)})
+    clock.t += 61.0
+    await mgr.tick()
+    assert states[-1][1]["event"] == "closed"
+    assert "idle" in states[-1][1]["reason"]
+
+
+async def test_reused_id_gets_hash_suffix(harness):
+    mgr, _results, states, _clock, tmp = harness
+    await mgr.handle_message("j1", {"action": "open", "path": str(tmp)})
+    await mgr.handle_message("j1", {"action": "stop"})
+    await mgr.handle_message("j1", {"action": "open", "path": str(tmp)})
+    reopened = states[-1][1]
+    assert reopened["event"] == "opened"
+    assert reopened["job_id"] == "j1"
+    assert reopened["effective_id"].startswith("j1.h")
+    assert len(reopened["effective_id"]) == len("j1.h") + 8
+
+
+async def test_job_limit_rejects(harness):
+    mgr, _results, states, _clock, tmp = harness
+    await mgr.handle_message("j1", {"action": "open", "path": str(tmp)})
+    await mgr.handle_message("j2", {"action": "open", "path": str(tmp)})
+    await mgr.handle_message("j3", {"action": "open", "path": str(tmp)})
+    assert states[-1][1]["event"] == "rejected"
+    assert "limit" in states[-1][1]["reason"]
+
+
+async def test_message_for_unknown_job_is_dropped(harness):
+    mgr, results, states, _clock, _tmp = harness
+    await mgr.handle_message("ghost", {"action": "stop"})
+    assert not results and not states


### PR DESCRIPTION
## What

New permanent TCS service `focus_calc_svc.focus_calc` — computes best-focus from FITS frames as NATS-driven **jobs**. Boilerplate + wire-protocol proposal for discussion; batch methods already work, dynamic search is a stub.

- **N concurrent jobs**, each bound to a frame directory (frames may pre-exist or trickle in during a scan — every new frame triggers re-evaluation, results improve iteratively)
- **M methods per job** on the same frames → one result message per method per round. Methods wrap `pyaraucaria.focus.Focus` (exactly what TOI runs today: `rms`, `rms_quad`, `fwhm`, `laplacian`, `lorentzian`); plug-in protocol reserves the contract for **dynamic-search** methods (`suggestion: next_position | stop`) — client drives the focuser, service never touches hardware
- **Sub/pub, not RPC** — a job is a long-lived conversation. Subject suffix = client-chosen job id (`focus.calc.job.<id.parts…>`); responses reuse it; reused-after-finish ids get `.h<hash>` announced in the `opened` event
- Job closure: `stop` message or idle timeout
- Standard TCS observability: status/heartbeat + metrics (method availability, active-job table, counters)

Full protocol spec with payload examples and **open questions for review**: `doc/focus-calc-service.md`.

## Layout

- `src/ocabox_tcs/services/focus_calc_svc/focus_calc.py` — service (subscriber, tick loop, metrics)
- `src/ocabox_tcs/services/focus_calc_svc/jobs.py` — `JobManager` (id/hash, polling, idle expiry; transport-agnostic)
- `src/ocabox_tcs/services/focus_calc_svc/methods.py` — method protocol + pyaraucaria adapters + `dynamic_search` stub
- `config/focus_calc.sample.yaml`, `doc/focus-calc-service.md`
- `pyproject.toml`: optional dep `pyaraucaria` + extra `focus`

## Testing

- 9 new unit tests (`tests/unit/test_focus_calc_jobs.py`) — job lifecycle, id-collision hashing, idle timeout, job limit; no NATS/pyaraucaria needed
- `tests/unit` (minus the launcher-harness files affected by the known post-merge debt): **262 passed**
- ruff clean; change is purely additive

## Notes

- JetStream stream covering `focus.calc.>` must be provisioned (oca_nats_config) before deploying
- Job-as-TCS-child monitoring deliberately deferred (roadmap Feature 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011adsTpyTD4CX161zxdXR3G